### PR TITLE
fix(Anomaly): add Reliable tag to Knife

### DIFF
--- a/lib/npc_features.json
+++ b/lib/npc_features.json
@@ -2626,6 +2626,10 @@
         "id": "tg_ap"
       },
       {
+        "id": "tg_reliable",
+        "val": "{1/2/3}"
+      },
+      {
         "id": "tg_seeking"
       },
       {


### PR DESCRIPTION
Forgot the Reliable tag for Extrude Knife.